### PR TITLE
8 support authentication via personal access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ devices via the [Mender](https://docs.mender.io/) client, without additional hos
 - [mender-client-docker](#mender-client-docker)
   - [Usage](#usage)
     - [`mender-client-docker-launcher` usage](#mender-client-docker-launcher-usage)
+      - [`mender-client-docker-launcher` inputs](#mender-client-docker-launcher-inputs)
     - [`mender-client-docker` usage](#mender-client-docker-usage)
 - [Contributing](#contributing)
   - [Build the image](#build-the-image)
@@ -27,23 +28,35 @@ The core Mender client functionality is provided by the `mender-client-docker` i
 `mender-client-docker-launcher` image offers a convenience layer to manage setup and bringup of a
 `mender-client-docker` container on a system, and is the recommended pattern.
 
-Both patterns require the `TENANT_TOKEN` variable to
+The `mender-client-docker` pattern requires a `TENANT_TOKEN` variable to
 [authenticate against the Mender host](https://docs.mender.io/client-installation/install-with-debian-package#configure-the-mender-client).
+The `mender-client-docker-launcher` can optionally pass the `TENANT_TOKEN` through, or can retrieve
+a value from the Mender API using a personal access token `MENDER_PAT` (recommended).
 
 ### `mender-client-docker-launcher` usage<a name="mender-client-docker-launcher-usage"></a>
 
 Basic usage:
 
 ```bash
-export TENANT_TOKEN=<Mender org token>
+export MENDER_PAT=<Mender personal access token>
 docker run \
   --rm \
   --name mender-client-docker-launcher \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -e TENANT_TOKEN \
+  -e MENDER_PAT \
   -e DEVICE_TYPE=<your device type> \
   ghcr.io/rcwbr/mender-client-docker-launcher:0.2.3
 ```
+
+#### `mender-client-docker-launcher` inputs<a name="mender-client-docker-launcher-inputs"></a>
+
+The following environment variables configure the `mender-client-docker-launcher`:
+
+| Variable       | Default                    | Effect                                                                                                      |
+| -------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `MENDER_HOST`  | `https://hosted.mender.io` | The URL of the Mender server instance against which to authenticate.                                        |
+| `MENDER_PAT`   | N/A                        | If provided, this is the access token used to authenticate to the Mender API and retrieve the tenant token. |
+| `TENANT_TOKEN` | N/A                        | If provided, this is the tenant token directly. Precludes the use of `MENDER_PAT`.                          |
 
 ### `mender-client-docker` usage<a name="mender-client-docker-usage"></a>
 

--- a/docker/mender-client-docker-launcher/Dockerfile
+++ b/docker/mender-client-docker-launcher/Dockerfile
@@ -1,5 +1,12 @@
 # hadolint ignore=DL3006
+FROM src_context AS src_context
+
+# hadolint ignore=DL3006
 FROM base_context
 
+RUN pip install --no-cache-dir requests==2.32.5
+
+COPY --from=src_context mender-client-docker-launcher.py /opt/mender-client-docker/mender-client-docker-launcher.py
 COPY docker-compose.yaml /opt/mender-client-docker/docker-compose.yaml
-ENTRYPOINT [ "docker", "compose", "-f", "/opt/mender-client-docker/docker-compose.yaml", "up", "--detach" ]
+COPY entrypoint /entrypoint
+ENTRYPOINT [ "/entrypoint" ]

--- a/docker/mender-client-docker-launcher/docker-bake.hcl
+++ b/docker/mender-client-docker-launcher/docker-bake.hcl
@@ -1,9 +1,30 @@
 // Expected to be used with https://github.com/rcwbr/dockerfile-partials/blob/main/github-cache-bake.hcl
 // For example, docker buildx bake -f github-cache-bake.hcl -f cwd://docker-bake.hcl https://github.com/rcwbr/dockerfile-partials.git#0.10.0
 
+target "docker-client" {
+  context    = "https://github.com/rcwbr/dockerfile_partials.git#0.10.0"
+  dockerfile = "docker-client/Dockerfile"
+  contexts = {
+    base_context = "docker-image://python:3.13.7"
+    docker_image = "docker-image://docker:27.3.1-cli"
+  }
+
+  // Adapted from https://github.com/rcwbr/dockerfile-partials/blob/main/github-cache-bake.hcl
+  cache-from = [
+    // Always pull cache from main
+    "type=registry,ref=${IMAGE_REF}-cache-docker-client:main",
+    "type=registry,ref=${IMAGE_REF}-cache-docker-client:${VERSION}"
+  ]
+  cache-to = [
+    "type=registry,rewrite-timestamp=true,mode=max,ref=${IMAGE_REF}-cache-docker-client:${VERSION}"
+  ]
+  output = []
+}
+
 target "default" {
   dockerfile = "cwd://Dockerfile"
   contexts = {
-    base_context = "docker-image://docker:27.3.1-cli"
+    base_context = "target:docker-client"
+    src_context  = "cwd://../../src"
   }
 }

--- a/docker/mender-client-docker-launcher/entrypoint
+++ b/docker/mender-client-docker-launcher/entrypoint
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+TENANT_TOKEN=$(python /opt/mender-client-docker/mender-client-docker-launcher.py)
+export TENANT_TOKEN
+
+docker compose -f /opt/mender-client-docker/docker-compose.yaml up --detach

--- a/src/mender-client-docker-launcher.py
+++ b/src/mender-client-docker-launcher.py
@@ -1,0 +1,28 @@
+import os
+
+import requests
+
+MENDER_PAT_ENV_KEY = 'MENDER_PAT'
+MENDER_HOST_ENV_KEY = 'MENDER_HOST'
+TENANT_TOKEN_ENV_KEY = 'TENANT_TOKEN'
+
+if TENANT_TOKEN_ENV_KEY in os.environ:
+  print(os.getenv(TENANT_TOKEN_ENV_KEY))
+elif MENDER_PAT_ENV_KEY in os.environ:
+  mender_host = os.getenv(MENDER_HOST_ENV_KEY, 'https://hosted.mender.io')
+  r = requests.get(
+    f'{mender_host}/api/management/v1/tenantadm/user/tenant',
+    headers = {
+      'Accept': '*/*',
+      'Authorization': f'Bearer {os.getenv(MENDER_PAT_ENV_KEY)}'
+    }
+  )
+  if r.status_code != 200:
+    print(
+      f'Tenant token get request failed: status={r.status_code}, text={r.text}, url={r.request.url}, headers={r.request.headers}'
+    )
+    r.raise_for_status()
+  else:
+    print(r.json()['tenant_token'])
+else:
+  raise ValueError('No Mender authentication configured.')


### PR DESCRIPTION
Closes #8 

> ## What
> 
> Support authenticating the client using a personal access token instead of the tenant token.
> 
> ## Why
> 
> To allow use of revokable, single-use keys and protect the static, shared organization/tenant token.
> 
> ## How
> 
> Read the [tenant token from the API](https://docs.mender.io/api/?python#management-api-tenants) after [authenticating via a provided personal access token](https://docs.mender.io/server-integration/using-the-apis#personal-access-tokens).
> 
