### PR TITLE
ci: fix launcher bake fs access

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -52,6 +52,7 @@ jobs:
           workdir: docker/mender-client-docker-launcher
           source: https://github.com/rcwbr/dockerfile-partials.git#0.10.0
           files: github-cache-bake.hcl, cwd://docker-bake.hcl
+          allow: fs.read=..
         env:
           REGISTRY: ghcr.io/rcwbr/
           IMAGE_NAME: mender-client-docker-launcher


### PR DESCRIPTION
Closes #8 

> ## What
> 
> Support authenticating the client using a personal access token instead of the tenant token.
> 
> ## Why
> 
> To allow use of revokable, single-use keys and protect the static, shared organization/tenant token.
> 
> ## How
> 
> Read the [tenant token from the API](https://docs.mender.io/api/?python#management-api-tenants) after [authenticating via a provided personal access token](https://docs.mender.io/server-integration/using-the-apis#personal-access-tokens).