### PR TITLE
11 support mac address matching from host device

### DIFF
--- a/.dive-ci
+++ b/.dive-ci
@@ -1,0 +1,4 @@
+rules:
+  lowestEfficiency: 0.99
+  highestWastedBytes: 11MB
+  highestUserWastedPercent: 0.9

--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -41,6 +41,7 @@ jobs:
           workdir: docker/mender-client-docker
           source: https://github.com/rcwbr/dockerfile-partials.git#0.10.0
           files: github-cache-bake.hcl, cwd://docker-bake.hcl
+          allow: fs.read=..
         env:
           REGISTRY: ghcr.io/rcwbr/
           IMAGE_NAME: mender-client-docker
@@ -57,7 +58,8 @@ jobs:
           REGISTRY: ghcr.io/rcwbr/
           IMAGE_NAME: mender-client-docker-launcher
     outputs:
-      docker-bake: ${{ steps.docker-bake.outputs.metadata }}
+      mender-client-docker: ${{ steps.docker-bake-mender-client-docker.outputs.metadata }}
+      mender-client-docker-launcher: ${{ steps.docker-bake-mender-client-docker-launcher.outputs.metadata }}
   devcontainer-cache-build:
     uses: rcwbr/devcontainer-cache-build/.github/workflows/devcontainer-cache-build.yaml@0.6.0
     permissions:
@@ -79,3 +81,37 @@ jobs:
     needs: devcontainer-cache-build
     with:
       pre-commit-image: ${{ fromJSON(needs.devcontainer-cache-build.outputs.devcontainer-cache-image-all_configs).target.pre-commit.args.DEVCONTAINER_PRE_COMMIT_IMAGE }}
+  dive-efficiency:
+    name: Dive Docker image space efficiency analysis
+    if: github.event_name == 'pull_request'
+    needs: build-docker-images
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.7
+      - name: GHCR Login
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dive analyze mender-client-docker
+        run: |
+          docker run \
+            --rm \
+            -e CI=true \
+            -v $(pwd)/.dive-ci:/etc/.dive-ci \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            wagoodman/dive:v0.12.0 \
+            --ci-config /etc/.dive-ci ${{ fromJSON(needs.build-docker-images.outputs.mender-client-docker).default['image.name'] }}
+      - name: Dive analyze mender-client-docker-launcher
+        run: |
+          docker run \
+            --rm \
+            -e CI=true \
+            -v $(pwd)/.dive-ci:/etc/.dive-ci \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            wagoodman/dive:v0.12.0 \
+            --ci-config /etc/.dive-ci ${{ fromJSON(needs.build-docker-images.outputs.mender-client-docker-launcher).default['image.name'] }}

--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -41,7 +41,7 @@ jobs:
           workdir: docker/mender-client-docker
           source: https://github.com/rcwbr/dockerfile-partials.git#0.10.0
           files: github-cache-bake.hcl, cwd://docker-bake.hcl
-          allow: fs.read=..
+          allow: fs.read=../..
         env:
           REGISTRY: ghcr.io/rcwbr/
           IMAGE_NAME: mender-client-docker
@@ -53,7 +53,7 @@ jobs:
           workdir: docker/mender-client-docker-launcher
           source: https://github.com/rcwbr/dockerfile-partials.git#0.10.0
           files: github-cache-bake.hcl, cwd://docker-bake.hcl
-          allow: fs.read=..
+          allow: fs.read=../..
         env:
           REGISTRY: ghcr.io/rcwbr/
           IMAGE_NAME: mender-client-docker-launcher

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ docker run \
   --name mender-client-docker-launcher \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -e MENDER_PAT \
+  -e MAC_ADDRESS=<e.g. $(cat /sys/class/net/eth0/address)> \
   -e DEVICE_TYPE=<your device type> \
   ghcr.io/rcwbr/mender-client-docker-launcher:0.3.1
 ```
@@ -52,11 +53,12 @@ docker run \
 
 The following environment variables configure the `mender-client-docker-launcher`:
 
-| Variable       | Default                    | Effect                                                                                                      |
-| -------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `MENDER_HOST`  | `https://hosted.mender.io` | The URL of the Mender server instance against which to authenticate.                                        |
-| `MENDER_PAT`   | N/A                        | If provided, this is the access token used to authenticate to the Mender API and retrieve the tenant token. |
-| `TENANT_TOKEN` | N/A                        | If provided, this is the tenant token directly. Precludes the use of `MENDER_PAT`.                          |
+| Variable       | Default                    | Effect                                                                                                                        |
+| -------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `MAC_ADDRESS`  | N/A                        | If provided, this becomes the MAC address associated with the client container, and thus the device as seen on Mender server. |
+| `MENDER_HOST`  | `https://hosted.mender.io` | The URL of the Mender server instance against which to authenticate.                                                          |
+| `MENDER_PAT`   | N/A                        | If provided, this is the access token used to authenticate to the Mender API and retrieve the tenant token.                   |
+| `TENANT_TOKEN` | N/A                        | If provided, this is the tenant token directly. Precludes the use of `MENDER_PAT`.                                            |
 
 ### `mender-client-docker` usage<a name="mender-client-docker-usage"></a>
 

--- a/docker/mender-client-docker-launcher/docker-compose.yaml
+++ b/docker/mender-client-docker-launcher/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     environment:
       DEVICE_TYPE: ${DEVICE_TYPE}
       TENANT_TOKEN: ${TENANT_TOKEN}
+    mac_address: ${MAC_ADDRESS}
     entrypoint: /setup-entrypoint
     volumes:
       # Saves the client configuration between container restarts
@@ -12,6 +13,7 @@ services:
   mender-client:
     image: ghcr.io/rcwbr/mender-client-docker:0.3.1
     container_name: mender-client
+    mac_address: ${MAC_ADDRESS}
     volumes:
       # Mount the setup from the mender-client-config container
       - mender-client-config:/etc/mender

--- a/docker/mender-client-docker-launcher/local-build
+++ b/docker/mender-client-docker-launcher/local-build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export REGISTRY=ghcr.io/rcwbr
+export IMAGE_NAME=mender-client-docker-launcher
+docker buildx bake -f github-cache-bake.hcl -f cwd://docker-bake.hcl https://github.com/rcwbr/dockerfile-partials.git#0.10.0

--- a/docker/mender-client-docker/local-build
+++ b/docker/mender-client-docker/local-build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export REGISTRY=ghcr.io/rcwbr
+export IMAGE_NAME=mender-client-docker
+docker buildx bake -f github-cache-bake.hcl -f cwd://docker-bake.hcl https://github.com/rcwbr/dockerfile-partials.git#0.10.0

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     environment:
       DEVICE_TYPE: virtual
       TENANT_TOKEN: ${TENANT_TOKEN}
+    mac_address: ${MAC_ADDRESS}
     entrypoint: /setup-entrypoint
     volumes:
       # Saves the client configuration between container restarts
@@ -13,6 +14,7 @@ services:
   mender-client:
     image: mender-client-docker
     container_name: mender-client
+    mac_address: ${MAC_ADDRESS}
     volumes:
       # Mount the setup from the mender-client-config container
       - mender-client-config:/etc/mender

--- a/test/test-launch
+++ b/test/test-launch
@@ -1,2 +1,6 @@
 #!/bin/bash
+
+MAC_ADDRESS="$(cat /sys/class/net/eth0/address)"
+export MAC_ADDRESS
+
 docker compose up -d

--- a/test/test-launcher-image
+++ b/test/test-launcher-image
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 docker run \
-  --rm \
   --name mender-client-docker-launcher \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -e TENANT_TOKEN \
+  -e MAC_ADDRESS="$(cat /sys/class/net/eth0/address)" \
+  -e MENDER_PAT \
   -e DEVICE_TYPE=virtual \
   mender-client-docker-launcher

--- a/test/test-updated-image
+++ b/test/test-updated-image
@@ -1,2 +1,6 @@
 #!/bin/bash
+
+MAC_ADDRESS="$(cat /sys/class/net/eth0/address)"
+export MAC_ADDRESS
+
 docker compose up -d --no-deps mender-client


### PR DESCRIPTION
Closes #11 

> ## What
> 
> Support matching the host device MAC address within the client container.
> 
> ## Why
> 
> To correctly match devices to their representation in Mender Server, and avoid multiple real devices using the client container to appear as the same device.
> 
> ## How
> 
> (Optionally) map the host MAC address through to the launcher container, and always map the launcher container MAC address to the setup and client containers.
> 