### PR TITLE
fix: avoid registration device type ignore

### DIFF
--- a/docker/mender-client-docker-launcher/docker-compose.yaml
+++ b/docker/mender-client-docker-launcher/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
     volumes:
       # Saves the client configuration between container restarts
       - mender-client-config:/etc/mender
+      # Saves the device type between container restarts
+      - mender-client-data:/var/lib/mender
   mender-client:
     image: ghcr.io/rcwbr/mender-client-docker:0.4.0
     container_name: mender-client

--- a/docker/mender-client-docker/Dockerfile
+++ b/docker/mender-client-docker/Dockerfile
@@ -2,7 +2,7 @@
 FROM base_context
 
 ARG DEBIAN_FRONTEND=noninteractive
-ENV DEVICE_TYPE=raspberrypi5
+ENV DEVICE_TYPE=none
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
   mkdir -p /run/dbus \


### PR DESCRIPTION
Closes #13 

> ## Expected behavior
> 
> Devices are registered with the device type provided to the client as DEVICE_TYPE
> 
> ## Observed behavior
> 
> Devices are registered as raspberrypi5
> 
> ## Proposed resolution
> 
> Remove ENV DEVICE_TYPE=raspberrypi5 from Dockerfile; ensure availability of env var during setup
> 