### PR TITLE
15 deployment fails on docker access

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ services:
     volumes:
       - mender-client-config:/etc/mender
       - mender-client-data:/var/lib/mender
+      - /var/run/docker.sock:/var/run/docker.sock
     restart: always
     depends_on:
       mender-client-setup:

--- a/docker/mender-client-docker-launcher/docker-compose.yaml
+++ b/docker/mender-client-docker-launcher/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
       - mender-client-config:/etc/mender
       # Saves the client key between container restarts
       - mender-client-data:/var/lib/mender
+      - /var/run/docker.sock:/var/run/docker.sock
     restart: always
     depends_on:
       mender-client-setup:

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
       - mender-client-config:/etc/mender
       # Saves the client key between container restarts
       - mender-client-data:/var/lib/mender
+      - /var/run/docker.sock:/var/run/docker.sock
     restart: always
     depends_on:
       mender-client-setup:


### PR DESCRIPTION
Closes #15 

> ## Expected behavior
> 
> On valid deployment of a container artifact, the client creates the appropriate containers.
> 
> ## Observed behavior
> 
> The deployment fails with the error "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"
> 
> ## Proposed resolution
> 
> Mount the Docker socket when creating the client container.
> 
