### PR TITLE
fix: container MAC address for latest engines

### DIFF
--- a/docker/mender-client-docker-launcher/docker-compose.yaml
+++ b/docker/mender-client-docker-launcher/docker-compose.yaml
@@ -5,7 +5,9 @@ services:
     environment:
       DEVICE_TYPE: ${DEVICE_TYPE}
       TENANT_TOKEN: ${TENANT_TOKEN}
-    mac_address: ${MAC_ADDRESS}
+    networks:
+      default:
+        mac_address: ${MAC_ADDRESS}
     entrypoint: /setup-entrypoint
     volumes:
       # Saves the client configuration between container restarts
@@ -15,7 +17,9 @@ services:
   mender-client:
     image: ghcr.io/rcwbr/mender-client-docker:0.5.0
     container_name: mender-client
-    mac_address: ${MAC_ADDRESS}
+    networks:
+      default:
+        mac_address: ${MAC_ADDRESS}
     volumes:
       # Mount the setup from the mender-client-config container
       - mender-client-config:/etc/mender

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -6,7 +6,9 @@ services:
     environment:
       DEVICE_TYPE: virtual
       TENANT_TOKEN: ${TENANT_TOKEN}
-    mac_address: ${MAC_ADDRESS}
+    networks:
+      default:
+        mac_address: ${MAC_ADDRESS}
     entrypoint: /setup-entrypoint
     volumes:
       # Saves the client configuration between container restarts
@@ -14,7 +16,9 @@ services:
   mender-client:
     image: mender-client-docker
     container_name: mender-client
-    mac_address: ${MAC_ADDRESS}
+    networks:
+      default:
+        mac_address: ${MAC_ADDRESS}
     volumes:
       # Mount the setup from the mender-client-config container
       - mender-client-config:/etc/mender


### PR DESCRIPTION
Closes #19 

> ## Expected behavior
> 
> The launcher establishes a consistent MAC address for the client container.
> 
> ## Observed behavior
> 
> When the container restarts, a new MAC address is set.
> 
> ## Proposed resolution
> 
> Migrate from "legacy" `service.mac_address` field to `service.networks.default.mac_address`.