### PR TITLE
fix: apply missing tag images from OCI files

### DIFF
--- a/docker/mender-client-docker/Dockerfile
+++ b/docker/mender-client-docker/Dockerfile
@@ -4,10 +4,13 @@ FROM base_context
 ARG DEBIAN_FRONTEND=noninteractive
 ENV DEVICE_TYPE=none
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN \
-  mkdir -p /run/dbus \
-  && apt-get update \
-  && apt-get install --allow-unauthenticated --no-install-recommends -y \
+ARG APP_MODULE_COMPOSE=/usr/share/mender/app-modules/v1/docker-compose
+# hadolint ignore=SC2016
+RUN <<EOF
+set -e
+mkdir -p /run/dbus
+apt-get update
+apt-get install --allow-unauthenticated --no-install-recommends -y \
     apt-transport-https=2.8.3* \
     ca-certificates=20240203* \
     curl=8.5.0* \
@@ -15,32 +18,36 @@ RUN \
     iproute2=6.1.0* \
     jq=1.7.1* \
     openssh-server=1:9.6p1* \
-    wget=1.21.4* \
-  && wget -qO- https://downloads.mender.io/repos/debian/gpg | tee /etc/apt/trusted.gpg.d/mender.asc \
-  && echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/debian ubuntu/noble/stable main" | tee /etc/apt/sources.list.d/mender.list \
-  && apt-get update \
-  && apt-get install --allow-unauthenticated --no-install-recommends -y \
+    wget=1.21.4*
+wget -qO- https://downloads.mender.io/repos/debian/gpg | tee /etc/apt/trusted.gpg.d/mender.asc
+echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/debian ubuntu/noble/stable main" | tee /etc/apt/sources.list.d/mender.list
+apt-get update
+apt-get install --allow-unauthenticated --no-install-recommends -y \
     mender-client4=5.0.1* \
     mender-connect=2.3.0* \
-    xdelta3=3.0.11* \
-  && apt-get clean \
-  && apt-get autoclean \
-  && apt-get autoremove \
-  && rm -rf /var/cache/debconf \
-  && rm -rf /var/lib/apt/lists/* \
-  && mkdir -p /usr/share/mender/modules/v3 \
-  && wget -q -P /usr/share/mender/modules/v3 https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/docker/module/docker \
-  && wget -q https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/src/app \
-          -O /usr/share/mender/modules/v3/app \
-          && chmod +x /usr/share/mender/modules/v3/app \
-  && mkdir -p /usr/share/mender/app-modules/v1 \
-  && wget -q https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/src/app-modules/docker-compose \
-          -O /usr/share/mender/app-modules/v1/docker-compose \
-          && chmod +x /usr/share/mender/app-modules/v1/docker-compose \
-  && wget -q https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/conf/mender-app.conf \
-          -O /etc/mender/mender-app.conf \
-  && wget -q https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/conf/mender-app-docker-compose.conf \
-        -O /etc/mender/mender-app-docker-compose.conf
+    xdelta3=3.0.11*
+    apt-get clean
+apt-get autoclean
+apt-get autoremove
+rm -rf /var/cache/debconf
+rm -rf /var/lib/apt/lists/*
+mkdir -p /usr/share/mender/modules/v3
+wget -q -P /usr/share/mender/modules/v3 https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/docker/module/docker
+wget -q https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/src/app \
+    -O /usr/share/mender/modules/v3/app
+    chmod +x /usr/share/mender/modules/v3/app
+mkdir -p /usr/share/mender/app-modules/v1
+wget -q https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/src/app-modules/docker-compose \
+    -O $APP_MODULE_COMPOSE
+    chmod +x $APP_MODULE_COMPOSE
+sed -i '/^\ \ \ \ \$docker_cmd image load < "\$input_file"$/a \
+\ \ \ \ input_sha=\$(tar -xf "\$input_file" index.json -O  | jq -r '\''.manifests[0].digest | ltrimstr("sha256:")'\'') \
+\ \ \ \ \$docker_cmd tag "\$input_sha" "\${url%%@sha256:*}"'  $APP_MODULE_COMPOSE
+wget -q https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/conf/mender-app.conf \
+    -O /etc/mender/mender-app.conf
+wget -q https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/conf/mender-app-docker-compose.conf \
+    -O /etc/mender/mender-app-docker-compose.conf
+EOF
 
 COPY entrypoint /entrypoint
 COPY setup-entrypoint /setup-entrypoint


### PR DESCRIPTION
Closes #21 

> ## Expected behavior
> 
> When an artifact contains an OCI image resource, the client loads this image such that it is available to `docker run`.
> 
> ## Observed behavior
> 
> ```bash
> record_id=8219 severity=info time="2026-Apr-28 01:28:56.430563" name="Global" msg="Update Module output (stdout): Loaded image ID: sha256:46b4916fc0cd44eea05adbab7ca5cba002a6916553230f7b57e27d7b22606d99" 
> record_id=8220 severity=info time="2026-Apr-28 01:28:56.437333" name="Global" msg="Update Module output (stdout): scanning /var/lib/mender/modules/v3/payloads/0000/tree/tmp/images/sha256:965454ed7847c3db750ea750dfbe01cf9233456e7fbe3572ffc8e34af7f225fb" 
> record_id=8221 severity=info time="2026-Apr-28 01:29:10.292045" name="Global" msg="Update Module output (stdout): Loaded image: mod-ui:latest" 
> ...
> record_id=8266 severity=info time="2026-Apr-28 01:29:20.564865" name="Global" msg="Update Module output (stdout):  Network nam-box-nam-box_default  Creating" 
> record_id=8267 severity=info time="2026-Apr-28 01:29:20.564896" name="Global" msg="Update Module output (stdout):  Network nam-box-nam-box_default  Created" 
> record_id=8268 severity=info time="2026-Apr-28 01:29:20.564916" name="Global" msg="Update Module output (stdout):  Container nam-box-nam-box-mdns-1  Creating" 
> record_id=8269 severity=info time="2026-Apr-28 01:29:20.564936" name="Global" msg="Update Module output (stdout):  Container nam-box-nam-box-mod-ui-1  Creating" 
> record_id=8270 severity=info time="2026-Apr-28 01:29:20.564955" name="Global" msg="Update Module output (stdout): Error response from daemon: No such image: mod-ui:latest" 
> ```
> 
> ```bash
> $ docker image ls mod-ui:latest
>                                                                                                                                                                                             i Info →   U  In Use
> IMAGE           ID             DISK USAGE   CONTENT SIZE   EXTRA
> mod-ui:latest   62a5df046b8d       1.58GB          409MB        
> mod-ui:latest   62a5df046b8d       1.58GB          409MB        
> $ docker inspect mod-ui:latest
> []
> error: no such object: mod-ui:latest
> ```
> 
> ## Proposed resolution
> 
> Override the docker-compose app-module from Mender app-update-module to explicitly `docker tag` after `docker image load`