### PR TITLE
feat: custom mender server support

### DIFF
--- a/docker/mender-client-docker-launcher/docker-compose.yaml
+++ b/docker/mender-client-docker-launcher/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
     container_name: mender-client-setup
     environment:
       DEVICE_TYPE: ${DEVICE_TYPE}
+      MENDER_HOST: ${MENDER_HOST}
       TENANT_TOKEN: ${TENANT_TOKEN}
     networks:
       default:

--- a/docker/mender-client-docker/setup-entrypoint
+++ b/docker/mender-client-docker/setup-entrypoint
@@ -1,11 +1,18 @@
 #!/bin/bash
 
-mender-setup \
-  --quiet \
-  --device-type "$DEVICE_TYPE" \
-  --demo=false \
-  --hosted-mender \
-  --tenant-token "$TENANT_TOKEN" \
-  --update-poll 5 \
-  --inventory-poll 600 \
+args=(
+  --device-type "$DEVICE_TYPE"
+  --inventory-poll 600
+  --quiet
   --retry-poll 5
+  --tenant-token "$TENANT_TOKEN"
+  --demo-server=false
+  --server-cert ""
+  --update-poll 5
+)
+
+if [ -n "$MENDER_HOST" ]; then
+  args+=(--server-url "$MENDER_HOST")
+fi
+
+mender-setup "${args[@]}"


### PR DESCRIPTION
Closes #23 

> ## What
> 
> The launcher accepts a MENDER_HOST variable, against which its initial API call is made, but the core client always reaches `https://hosted.mender.io`
> 
> ## Why
> 
> To allow use with self-hosted Mender servers.
> 
> ## How
> 
> Forward the MENDER_HOST variable into the setup script.