### PR TITLE
fix: read image hash using skopeo

### DIFF
--- a/docker/mender-client-docker/Dockerfile
+++ b/docker/mender-client-docker/Dockerfile
@@ -41,12 +41,14 @@ wget -q https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0
     -O $APP_MODULE_COMPOSE
     chmod +x $APP_MODULE_COMPOSE
 sed -i '/^\ \ \ \ \$docker_cmd image load < "\$input_file"$/a \
-\ \ \ \ input_sha=\$(tar -xf "\$input_file" index.json -O  | jq -r '\''.manifests[0].digest | ltrimstr("sha256:")'\'') \
+\ \ \ \ input_sha=\$(skopeo inspect "oci-archive://\$input_file" | jq -r '\''.Digest | ltrimstr("sha256:")'\'') \
 \ \ \ \ \$docker_cmd tag "\$input_sha" "\${url%%@sha256:*}"'  $APP_MODULE_COMPOSE
 wget -q https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/conf/mender-app.conf \
     -O /etc/mender/mender-app.conf
 wget -q https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/conf/mender-app-docker-compose.conf \
     -O /etc/mender/mender-app-docker-compose.conf
+wget -q https://github.com/lework/skopeo-binary/releases/download/v1.22.0/skopeo-linux-amd64 -O /usr/bin/skopeo \
+    && chmod +x /usr/bin/skopeo
 EOF
 
 COPY entrypoint /entrypoint


### PR DESCRIPTION
Closes #21 

> ## Expected behavior
> 
> When an artifact contains an OCI image resource, the client loads this image such that it is available to `docker run`.
> 
> ## Observed behavior
> 
> ```bash
> record_id=8219 severity=info time="2026-Apr-28 01:28:56.430563" name="Global" msg="Update Module output (stdout): Loaded image ID: sha256:46b4916fc0cd44eea05adbab7ca5cba002a6916553230f7b57e27d7b22606d99" 
> record_id=8220 severity=info time="2026-Apr-28 01:28:56.437333" name="Global" msg="Update Module output (stdout): scanning /var/lib/mender/modules/v3/payloads/0000/tree/tmp/images/sha256:965454ed7847c3db750ea750dfbe01cf9233456e7fbe3572ffc8e34af7f225fb" 
> record_id=8221 severity=info time="2026-Apr-28 01:29:10.292045" name="Global" msg="Update Module output (stdout): Loaded image: mod-ui:latest" 
> ...
> record_id=8266 severity=info time="2026-Apr-28 01:29:20.564865" name="Global" msg="Update Module output (stdout):  Network nam-box-nam-box_default  Creating" 
> record_id=8267 severity=info time="2026-Apr-28 01:29:20.564896" name="Global" msg="Update Module output (stdout):  Network nam-box-nam-box_default  Created" 
> record_id=8268 severity=info time="2026-Apr-28 01:29:20.564916" name="Global" msg="Update Module output (stdout):  Container nam-box-nam-box-mdns-1  Creating" 
> record_id=8269 severity=info time="2026-Apr-28 01:29:20.564936" name="Global" msg="Update Module output (stdout):  Container nam-box-nam-box-mod-ui-1  Creating" 
> record_id=8270 severity=info time="2026-Apr-28 01:29:20.564955" name="Global" msg="Update Module output (stdout): Error response from daemon: No such image: mod-ui:latest" 
> ```
> 
> ```bash
> $ docker image ls mod-ui:latest
>                                                                                                                                                                                             i Info →   U  In Use
> IMAGE           ID             DISK USAGE   CONTENT SIZE   EXTRA
> mod-ui:latest   62a5df046b8d       1.58GB          409MB        
> mod-ui:latest   62a5df046b8d       1.58GB          409MB        
> $ docker inspect mod-ui:latest
> []
> error: no such object: mod-ui:latest
> ```
> 
> ## Proposed resolution
> 
> Override the docker-compose app-module from Mender app-update-module to explicitly `docker tag` after `docker image load`